### PR TITLE
Update license name

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/README.md
+++ b/README.md
@@ -3,13 +3,25 @@ About libgd
 
 Home: http://libgd.github.io/
 
-Package license: GD license
+Package license: GD
 
 Feedstock license: BSD 3-Clause
 
 Summary: library for the dynamic creation of images
 
 
+
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/libgd-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/libgd-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/libgd-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/libgd-feedstock)
+Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/libgd/badges/version.svg)](https://anaconda.org/conda-forge/libgd)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/libgd/badges/downloads.svg)](https://anaconda.org/conda-forge/libgd)
 
 Installing libgd
 ================
@@ -31,7 +43,6 @@ It is possible to list all of the versions of `libgd` available on your platform
 ```
 conda search libgd --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -67,18 +78,6 @@ Terminology
 
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
-
-Current build status
-====================
-
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/libgd-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/libgd-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/libgd-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/libgd-feedstock)
-Windows: ![](https://cdn.rawgit.com/conda-forge/conda-smithy/90845bba35bec53edac7a16638aa4d77217a3713/conda_smithy/static/disabled.svg)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/libgd/badges/version.svg)](https://anaconda.org/conda-forge/libgd)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/libgd/badges/downloads.svg)](https://anaconda.org/conda-forge/libgd)
 
 
 Updating libgd-feedstock

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 
 build:
   skip: true  # [win]
-  number: 1
+  number: 2
 
 requirements:
   build:
@@ -24,7 +24,7 @@ requirements:
     - jpeg 9*
     - libpng >=1.6.23,<1.7
     - libtiff 4.0.*
-    - fontconfig 2.11.*
+    - fontconfig 2.12.*
     - libiconv
     - expat
   run:
@@ -33,7 +33,7 @@ requirements:
     - jpeg 9*
     - libpng >=1.6.23,<1.7
     - libtiff 4.0.*
-    - fontconfig 2.11.*
+    - fontconfig 2.12.*
     - libiconv
     - expat
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -45,8 +45,8 @@ test:
 about:
     home: http://libgd.github.io/
     summary: library for the dynamic creation of images
-    license: GD license
-    license_family: Other
+    license: GD
+    license_family: BSD
     license_file: COPYING
 
 extra:


### PR DESCRIPTION
Changed the license name to make the linter happy.

@jakirkham, can you check if the license renaming makes sense? BSD-like is way more descriptive than GD license. I took it from wikipedia. https://en.wikipedia.org/wiki/GD_Graphics_Library

Not sure though if that's a license, or a license_family in conda-forge. license: custom, license_family: BSD-like or license: custom, license_family: BSD could fit as well, I guess. Any preferences?